### PR TITLE
Introduce batch-size on worker and pull less items from NATS subject but process them quickly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,7 @@ func init() {
 	workerCmd.PersistentFlags().String("nats-url", "", "NATS server URL (env: PG_FLO_NATS_URL)")
 	workerCmd.PersistentFlags().String("rules-config", "", "Path to rules configuration file (env: PG_FLO_RULES_CONFIG)")
 	workerCmd.PersistentFlags().String("routing-config", "", "Path to routing configuration file (env: PG_FLO_ROUTING_CONFIG)")
+	workerCmd.PersistentFlags().Int("batch-size", 1000, "Number of messages to process in a batch (env: PG_FLO_BATCH_SIZE)")
 
 	markPersistentFlagRequired(workerCmd, "group", "nats-url")
 
@@ -290,7 +291,14 @@ func runWorker(cmd *cobra.Command, _ []string) {
 		log.Fatal().Err(err).Msg("Failed to create sink")
 	}
 
-	w := worker.NewWorker(natsClient, ruleEngine, router, sink, group)
+	w := worker.NewWorker(
+		natsClient,
+		ruleEngine,
+		router,
+		sink,
+		group,
+		worker.WithBatchSize(viper.GetInt("batch-size")),
+	)
 
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()

--- a/internal/pg-flo.yaml
+++ b/internal/pg-flo.yaml
@@ -19,6 +19,7 @@ track-ddl: false # Enable tracking of DDL changes (env: PG_FLO_TRACK_DDL)
 nats-url: "nats://localhost:4222" # NATS server URL (env: PG_FLO_NATS_URL)
 
 # Worker settings
+batch-size: 1000 # Number of messages to process in a batch (env: PG_FLO_BATCH_SIZE)
 rules-config: "/path/to/rules.yaml" # Path to rules configuration file (env: PG_FLO_RULES_CONFIG)
 routing-config: "/path/to/routing.yaml" # Path to routing configuration file (env: PG_FLO_ROUTING_CONFIG)
 

--- a/internal/scripts/e2e_copy_and_stream.sh
+++ b/internal/scripts/e2e_copy_and_stream.sh
@@ -109,6 +109,7 @@ start_pg_flo_worker() {
     --target-dbname "$TARGET_PG_DB" \
     --target-user "$TARGET_PG_USER" \
     --target-password "$TARGET_PG_PASSWORD" \
+    --batch-size 5000 \
     --target-sync-schema \
     >"$pg_flo_WORKER_LOG" 2>&1 &
   pg_flo_WORKER_PID=$!

--- a/internal/scripts/e2e_postgres.sh
+++ b/internal/scripts/e2e_postgres.sh
@@ -68,7 +68,7 @@ start_pg_flo_worker() {
 
 simulate_changes() {
   log "Simulating changes..."
-  local insert_count=1000
+  local insert_count=6000
 
   for i in $(seq 1 "$insert_count"); do
     run_sql "INSERT INTO public.users (data, nullable_column, toasted_column) VALUES ('Data $i', 'Nullable $i', 'Toasted $i');"

--- a/internal/scripts/e2e_test_local.sh
+++ b/internal/scripts/e2e_test_local.sh
@@ -31,116 +31,12 @@ trap cleanup EXIT
 
 make build
 
-# setup_docker
-
-# log "Running e2e order tests..."
-# if CI=false ruby ./internal/scripts/e2e_order_test.rb; then
-#   success "Original e2e tests completed successfully"
-# else
-#   error "Original e2e tests failed"
-#   exit 1
-# fi
-
-# log "Running e2e routing tests..."
-# if CI=false ./internal/scripts/e2e_routing.sh; then
-#   success "Original e2e tests completed successfully"
-# else
-#   error "Original e2e tests failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# log "Running e2e copy & stream tests..."
-# if CI=false ./internal/scripts/e2e_copy_and_stream.sh; then
-#   success "Original e2e tests completed successfully"
-# else
-#   error "Original e2e tests failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# log "Running e2e copy only tests..."
-# if CI=false ./internal/scripts/e2e_copy_only.sh; then
-#   success "Original e2e tests completed successfully"
-# else
-#   error "Original e2e tests failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# log "Running e2e copy & stream tests..."
-# if CI=false ./internal/scripts/e2e_multi_tenant.sh; then
-#   success "Original e2e tests completed successfully"
-# else
-#   error "Original e2e tests failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# log "Running new e2e stream tests with changes..."
-# if ./internal/scripts/e2e_test_stream.sh; then
-#   success "New e2e tests with changes completed successfully"
-# else
-#   error "New e2e tests with changes failed"
-#   exit 1
-# fi
-
 setup_docker
 
-# Run new e2e resume test
-log "Running new e2e resume test..."
-if ruby ./internal/scripts/e2e_resume_test.rb; then
-  success "E2E resume test completed successfully"
+log "Running e2e copy & stream tests..."
+if CI=false ./internal/scripts/e2e_copy_and_stream.sh; then
+  success "Original e2e tests completed successfully"
 else
-  error "E2E resume test failed"
+  error "Original e2e tests failed"
   exit 1
 fi
-
-# setup_docker
-
-# # Run new e2e test for transform & filter
-# log "Running new e2e test for transform & filter..."
-# if ./internal/scripts/e2e_transform_filter.sh; then
-#   success "E2E test for transform & filter test completed successfully"
-# else
-#   error "E2E test for transform & filter test failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# # Run new e2e test for DDL changes
-# log "Running new e2e test for DDL changes..."
-# if ./internal/scripts/e2e_ddl.sh; then
-#   success "E2E test for DDL changes completed successfully"
-# else
-#   error "E2E test for DDL changes failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# Run new e2e test for Postgres changes
-# log "Running new e2e test Postgres Sink..."
-# if ./internal/scripts/e2e_postgres.sh; then
-#   success "E2E test for Postgres Sink completed successfully"
-# else
-#   error "E2E test for Postgres Sink failed"
-#   exit 1
-# fi
-
-# setup_docker
-
-# log "Running new e2e test Postgres Sink..."
-# if ./internal/scripts/e2e_postgres_data_type.sh; then
-#   success "E2E test for Postgres Sink completed successfully"
-# else
-#   error "E2E test for Postgres Sink failed"
-#   exit 1
-# fi
-
-success "All local e2e tests completed successfully"

--- a/pkg/replicator/copy_and_stream_replicator.go
+++ b/pkg/replicator/copy_and_stream_replicator.go
@@ -296,7 +296,7 @@ func (r *CopyAndStreamReplicator) CopyTableRange(ctx context.Context, tableName 
 	}
 
 	query := r.buildCopyQuery(tableName, startPage, endPage)
-	return r.executeCopyQuery(ctx, tx, query, schema, tableName, startPage, endPage, workerID)
+	return r.executeCopyQuery(ctx, tx, query, schema, tableName, workerID)
 }
 
 // setTransactionSnapshot sets the transaction snapshot.
@@ -329,7 +329,7 @@ func (r *CopyAndStreamReplicator) buildCopyQuery(tableName string, startPage, en
 }
 
 // executeCopyQuery executes the copy query and publishes the results to NATS.
-func (r *CopyAndStreamReplicator) executeCopyQuery(ctx context.Context, tx pgx.Tx, query, schema, tableName string, startPage, endPage uint32, workerID int) (int64, error) {
+func (r *CopyAndStreamReplicator) executeCopyQuery(ctx context.Context, tx pgx.Tx, query, schema, tableName string, workerID int) (int64, error) {
 	r.Logger.Debug().Str("copyQuery", query).Int("workerID", workerID).Msg("Executing initial copy query")
 
 	rows, err := tx.Query(context.Background(), query)
@@ -395,8 +395,6 @@ func (r *CopyAndStreamReplicator) executeCopyQuery(ctx context.Context, tx pgx.T
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("error during row iteration: %v", err)
 	}
-
-	r.Logger.Info().Str("table", tableName).Int("start_page", int(startPage)).Int("end_page", int(endPage)).Int64("rows_copied", copyCount).Msg("Copied table range")
 
 	return copyCount, nil
 }


### PR DESCRIPTION
- Short pulls from NATS allows the processMessages to go faster, combined that with a larger batch-size, inserts can go 5-7k/s depending
- Minor cleanup

closes https://github.com/shayonj/pg_flo/issues/33