### PR TITLE
Sustain network issues when writing to destination with backoff retries

### DIFF
--- a/internal/scripts/e2e_postgres.sh
+++ b/internal/scripts/e2e_postgres.sh
@@ -59,6 +59,7 @@ start_pg_flo_worker() {
     --target-dbname "$TARGET_PG_DB" \
     --target-user "$TARGET_PG_USER" \
     --target-password "$TARGET_PG_PASSWORD" \
+    --batch-size 5000 \
     --target-sync-schema \
     >"$pg_flo_WORKER_LOG" 2>&1 &
   pg_flo_WORKER_PID=$!

--- a/internal/scripts/e2e_test_local.sh
+++ b/internal/scripts/e2e_test_local.sh
@@ -33,8 +33,8 @@ make build
 
 setup_docker
 
-log "Running e2e copy & stream tests..."
-if CI=false ./internal/scripts/e2e_copy_and_stream.sh; then
+log "Running e2e postgres tests..."
+if CI=false ./internal/scripts/e2e_postgres.sh; then
   success "Original e2e tests completed successfully"
 else
   error "Original e2e tests failed"

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"context"
+	"time"
+)
+
+type RetryConfig struct {
+	MaxAttempts int
+	InitialWait time.Duration
+	MaxWait     time.Duration
+}
+
+func WithRetry(ctx context.Context, cfg RetryConfig, operation func() error) error {
+	wait := cfg.InitialWait
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := operation()
+		if err == nil {
+			return nil
+		}
+
+		if attempt == cfg.MaxAttempts {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+			// Exponential backoff with max wait
+			wait *= 2
+			if wait > cfg.MaxWait {
+				wait = cfg.MaxWait
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Lets say if the target DB is unavailable, it will go into a retry back off w/o dropping any writes/updates and resumes from where it left off. 

Example
<img width="1871" alt="image" src="https://github.com/user-attachments/assets/313820af-a5a0-4cf5-b8f5-66d37825e463">


Closes https://github.com/shayonj/pg_flo/issues/2